### PR TITLE
Add initial GitHub Actions CI (ruff + pytest on 3.11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Lint (ruff)
+        run: poetry run ruff check .
+
+      - name: Test (unit)
+        run: poetry run pytest -m "not integration"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,11 +2,10 @@
 
 import os
 import shlex
+import tomllib
 from pathlib import Path
 
 import pytest
-import tomllib
-
 from project_wrap.core import (
     build_bwrap_args,
     build_shell_argv,

--- a/tests/test_vault_integration.py
+++ b/tests/test_vault_integration.py
@@ -19,7 +19,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from project_wrap import deps as deps_module
 
 pytestmark = [pytest.mark.integration, pytest.mark.real_probe]


### PR DESCRIPTION
## Summary

Initial CI workflow for the repo. Runs on push to `main` and on PRs targeting `main`.

**Scope (intentionally narrow):**
- Ubuntu latest runner.
- Python 3.11 only (matrix to 3.12/3.13 tracked in #8).
- `poetry install` via pipx-installed Poetry, with `actions/setup-python` poetry cache.
- `poetry run ruff check .`
- `poetry run pytest -m "not integration"` — integration tests need bwrap+gocryptfs+userns and are tracked in #9.
- mypy is tracked in #7.

**Bundled cleanup:** two pre-existing `I001` import-sort violations in `tests/test_core.py` and `tests/test_vault_integration.py` that would have turned the first CI run red. Fixed via `ruff check --fix`; separate commit from the workflow file.

## Test plan
- [ ] CI job runs and passes on this PR.
- [ ] Workflow triggers on push to main after merge.
- [ ] After merge, rebase `refactor/scaffold-module` onto main so its PR is gated by this CI.
