### PR TITLE
Fix #2, comment out missing paths from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,10 @@ When sandboxing is enabled:
 
 - Home is **read-only**; only the project directory is writable
 - Config directory (`~/.config/pwrap`) is always blacklisted
-- Docker socket (`/run/docker.sock`) masked — `connect()` works on
-  ro-bound sockets, so an exposed docker socket is a full escape to root
+- Docker sockets masked at `/run/docker.sock`, `/var/run/docker.sock`,
+  `~/.docker/desktop/docker-cli.sock`, `~/.docker/run/docker.sock` —
+  `connect()` works on ro-bound sockets, so an exposed docker socket is a
+  full escape to root. Override via `writable` to enable docker access.
 - Default template blacklists credential dirs (SSH, GPG, AWS, GCP, Azure,
   Docker, npm, PyPI) and `/mnt` (WSL Windows drives)
 - PID and IPC namespaces are isolated

--- a/src/project_wrap/core.py
+++ b/src/project_wrap/core.py
@@ -34,6 +34,14 @@ class ProjectExec:
     vault_config: VaultConfig | None = None
 
 
+_DOCKER_SOCKET_CANDIDATES = [
+    "/run/docker.sock",
+    "/var/run/docker.sock",
+    "~/.docker/desktop/docker-cli.sock",
+    "~/.docker/run/docker.sock",
+]
+
+
 def get_config_dir() -> Path:
     """Get the project configuration directory."""
     # Support XDG, fall back to ~/.config
@@ -118,9 +126,13 @@ def build_bwrap_args(
     uid = os.getuid()
     args.extend(["--tmpfs", f"/run/user/{uid}"])
 
-    # Mask docker socket — connect() works on ro-bound sockets, so this
-    # is a full sandbox escape to root if docker is running
-    args.extend(["--ro-bind-try", "/dev/null", "/run/docker.sock"])
+    # Mask docker sockets — connect() works on ro-bound sockets, so any
+    # accessible socket is a sandbox escape to root if docker is running.
+    # Cover the common locations; add others via writable to override.
+    for sock in _DOCKER_SOCKET_CANDIDATES:
+        sock_path = expand_path(sock)
+        if os.path.lexists(str(sock_path)):
+            args.extend(["--ro-bind", "/dev/null", str(sock_path)])
 
     # Always blacklist the config directory (prevents reading other project configs
     # or modifying sandbox rules from inside the sandbox)

--- a/src/project_wrap/scaffold.py
+++ b/src/project_wrap/scaffold.py
@@ -3,10 +3,50 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 from . import core
 from .validate import validate_project_name
+
+_SCANNED_LIST_KEYS = {"blacklist", "whitelist", "writable"}
+_LIST_START_RE = re.compile(r"^\s*(\w+)\s*=\s*\[")
+_STRING_ENTRY_RE = re.compile(r'^\s*"([^"]*)"')
+
+
+def _comment_missing_paths(toml_text: str) -> str:
+    """Comment out blacklist/whitelist/writable entries whose paths don't exist.
+
+    Line-based so template comments and formatting survive. Only uncommented
+    string entries are considered; already-commented lines are left as-is.
+    """
+    out: list[str] = []
+    in_scanned_list = False
+    for line in toml_text.splitlines():
+        stripped = line.lstrip()
+        if not in_scanned_list:
+            m = _LIST_START_RE.match(line)
+            if m and m.group(1) in _SCANNED_LIST_KEYS:
+                in_scanned_list = True
+            out.append(line)
+            continue
+        if stripped.startswith("]"):
+            in_scanned_list = False
+            out.append(line)
+            continue
+        if not stripped or stripped.startswith("#"):
+            out.append(line)
+            continue
+        entry = _STRING_ENTRY_RE.match(line)
+        if entry and not core.expand_path(entry.group(1)).exists():
+            indent = line[: len(line) - len(stripped)]
+            out.append(f"{indent}# {stripped}  # path not found on host")
+            continue
+        out.append(line)
+    result = "\n".join(out)
+    if toml_text.endswith("\n"):
+        result += "\n"
+    return result
 
 
 def _load_package_template(name: str) -> str:
@@ -89,6 +129,7 @@ def create_project(
     toml = _load_template("project.toml").format(
         name=name, dir=resolved_dir, sandbox_enabled=sandbox_enabled, shell=shell
     )
+    toml = _comment_missing_paths(toml)
 
     config_dir.mkdir(parents=True)
     config_dir.chmod(0o700)

--- a/src/project_wrap/templates/project.toml
+++ b/src/project_wrap/templates/project.toml
@@ -27,8 +27,14 @@ blacklist = [                     # Paths to hide (overlaid with tmpfs)
 #                                  # so DNS breaks without it when /mnt is blacklisted.
 #                                  # Add "/mnt/wslg/..." writable for GUI apps.
 # ]
-# writable = [                    # Extra writable paths (home is read-only)
+# writable = [                    # Extra writable paths (home is read-only).
 #     "~/.pyenv/shims",
+#     # To enable docker inside the sandbox, uncomment the matching socket
+#     # below (this overrides the default docker-socket mask):
+#     # "/run/docker.sock",                   # system docker
+#     # "/var/run/docker.sock",               # alt system docker
+#     # "~/.docker/desktop/docker-cli.sock",  # Docker Desktop (Linux)
+#     # "~/.docker/run/docker.sock",          # Docker Desktop alt
 # ]
 # unshare_net = false             # Isolate network namespace
 # unshare_pid = true              # Isolate PID namespace (default: true)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures."""
 
 import pytest
+from project_wrap import core as core_module
 from project_wrap import deps as deps_module
 
 
@@ -18,3 +19,13 @@ def _stub_bwrap_probe(request, monkeypatch):
     stub = lambda _path: (True, "")  # noqa: E731
     monkeypatch.setattr(deps_module, "_probe_bwrap", stub)
     monkeypatch.setattr(deps_module.DEPS["bwrap"], "feature_probe", stub)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_docker_socket_candidates(monkeypatch):
+    """Default build_bwrap_args tests to no docker sockets on host.
+
+    Tests that assert docker-mask behavior override this by monkeypatching
+    _DOCKER_SOCKET_CANDIDATES to a controlled list.
+    """
+    monkeypatch.setattr(core_module, "_DOCKER_SOCKET_CANDIDATES", [])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -156,6 +156,22 @@ class TestBuildBwrapArgs:
         idx = result.index(runtime_dir)
         assert result[idx - 1] == "--tmpfs"
 
+    def test_docker_socket_masked_when_present(self, tmp_path, monkeypatch):
+        sock = tmp_path / "docker.sock"
+        sock.touch()
+        absent = tmp_path / "nonexistent.sock"
+
+        monkeypatch.setattr(
+            "project_wrap.core._DOCKER_SOCKET_CANDIDATES",
+            [str(sock), str(absent)],
+        )
+        result = build_bwrap_args({}, tmp_path)
+
+        idx = result.index(str(sock))
+        assert result[idx - 1] == "/dev/null"
+        assert result[idx - 2] == "--ro-bind"
+        assert str(absent) not in result
+
     def test_blacklist_args(self, tmp_path):
         blacklist_dir = tmp_path / "secret"
         blacklist_dir.mkdir()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -5,7 +5,11 @@ import tomllib
 from pathlib import Path
 
 import pytest
-from project_wrap.scaffold import create_project, ensure_templates
+from project_wrap.scaffold import (
+    _comment_missing_paths,
+    create_project,
+    ensure_templates,
+)
 from project_wrap.validate import check_config_permissions, validate_config
 
 
@@ -207,3 +211,97 @@ class TestEnsureTemplates:
 
         init_content = (result / "init.fish").read_text()
         assert "my custom fish init" in init_content
+
+
+class TestCommentMissingPaths:
+    """Tests for _comment_missing_paths."""
+
+    def test_comments_missing_entry(self, tmp_path):
+        present = tmp_path / "exists"
+        present.mkdir()
+        missing = tmp_path / "nope"
+
+        toml = (
+            "[sandbox]\n"
+            "blacklist = [\n"
+            f'    "{present}",\n'
+            f'    "{missing}",\n'
+            "]\n"
+        )
+        result = _comment_missing_paths(toml)
+
+        assert f'"{present}"' in result
+        assert f'# "{missing}"' in result
+        assert "path not found on host" in result
+
+    def test_leaves_already_commented_lines(self, tmp_path):
+        missing = tmp_path / "nope"
+        toml = (
+            "[sandbox]\n"
+            "blacklist = [\n"
+            f'    # "{missing}",\n'
+            "]\n"
+        )
+        result = _comment_missing_paths(toml)
+
+        assert result.count("#") == 1
+
+    def test_preserves_valid_toml(self, tmp_path):
+        import tomllib as _toml
+
+        missing = tmp_path / "nope"
+        toml = (
+            "[sandbox]\n"
+            "blacklist = [\n"
+            f'    "{missing}",\n'
+            "]\n"
+            "writable = []\n"
+        )
+        result = _comment_missing_paths(toml)
+
+        parsed = _toml.loads(result)
+        assert parsed["sandbox"]["blacklist"] == []
+
+    def test_does_not_touch_other_sections(self, tmp_path):
+        missing = tmp_path / "nope"
+        toml = (
+            "[project]\n"
+            f'dir = "{missing}"\n'
+            "[sandbox]\n"
+            "blacklist = []\n"
+        )
+        result = _comment_missing_paths(toml)
+
+        assert f'dir = "{missing}"' in result
+
+    def test_expands_tilde(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        present = home / "exists"
+        present.mkdir()
+
+        toml = (
+            "[sandbox]\n"
+            "blacklist = [\n"
+            '    "~/exists",\n'
+            '    "~/missing",\n'
+            "]\n"
+        )
+        result = _comment_missing_paths(toml)
+
+        assert '    "~/exists",\n' in result
+        assert '# "~/missing"' in result
+
+    def test_full_default_template_renders_valid_toml(self, tmp_path):
+        """Regression: default template passed through must parse as TOML."""
+        import tomllib as _toml
+
+        from project_wrap.scaffold import _load_package_template
+
+        rendered = _load_package_template("project.toml").format(
+            name="t", dir=str(tmp_path), sandbox_enabled="true", shell="/bin/bash"
+        )
+        commented = _comment_missing_paths(rendered)
+        _toml.loads(commented)  # Should not raise


### PR DESCRIPTION
* Add any existing well-known docker socket path to blacklist
* Add them to example writable list as well for re-enabling
* Comment out white/black/writable list entries that does not exsist on --new