### PR TITLE
Aggregate missing blacklist/writable paths into one error, stop host mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ When sandboxing is enabled:
 - XDG runtime directory isolated (D-Bus, Wayland, keyring sockets)
 - Sandbox dies with parent process
 - Encrypted volumes mount in isolated namespace (invisible on host)
-- Writable paths are auto-created (as directories) if they don't exist;
-  paths that already exist are bound as-is, so a file entry binds that file
+- Writable and blacklist paths must exist on the host; missing entries
+  abort with a single aggregated error listing every missing path
 
 Run your editor from inside the sandbox if it has any capacity to run
 linters, hooks, or anything else from the project environment. A

--- a/src/project_wrap/core.py
+++ b/src/project_wrap/core.py
@@ -140,15 +140,34 @@ def build_bwrap_args(
     if config_dir_resolved.exists():
         args.extend(["--tmpfs", str(config_dir_resolved)])
 
-    # Blacklist paths by overlaying with tmpfs (dirs) or /dev/null (files)
-    blacklist_paths: list[Path] = [config_dir_resolved]
+    # Validate blacklist and writable up front so the user sees every missing
+    # path in one error, rather than one-per-run. Whitelist is "exception to
+    # blacklist" and silently skips missing entries by design.
+    missing: list[tuple[str, Path]] = []
+    blacklist_expanded: list[Path] = []
     for path in sandbox.get("blacklist", []):
         p = expand_path(path)
         if not p.exists():
-            raise SystemExit(
-                f"Blacklist path does not exist: {p}\n"
-                f"Fix your config or remove this entry."
-            )
+            missing.append(("blacklist", p))
+        else:
+            blacklist_expanded.append(p)
+    writable_expanded: list[Path] = []
+    for path in sandbox.get("writable", []):
+        p = expand_path(path)
+        if not p.exists():
+            missing.append(("writable", p))
+        else:
+            writable_expanded.append(p)
+    if missing:
+        lines = "\n".join(f"  [{kind}] {p}" for kind, p in missing)
+        raise SystemExit(
+            f"Config references paths that do not exist on this host:\n{lines}\n"
+            f"Fix your config (comment out the missing entries or adjust the paths)."
+        )
+
+    # Blacklist paths by overlaying with tmpfs (dirs) or /dev/null (files)
+    blacklist_paths: list[Path] = [config_dir_resolved]
+    for p in blacklist_expanded:
         # bwrap can't mount tmpfs over symlinks — resolve to the real path
         mount_path = p.resolve()
         if mount_path.is_file():
@@ -172,10 +191,7 @@ def build_bwrap_args(
         args.extend(["--bind", str(resolved), str(resolved)])
 
     # Extra writable paths (e.g. ~/.pyenv/shims, ~/.keychain)
-    for path in sandbox.get("writable", []):
-        p = expand_path(path)
-        if not p.exists():
-            p.mkdir(parents=True, exist_ok=True)
+    for p in writable_expanded:
         mount_path = p.resolve()
         args.extend(["--bind", str(mount_path), str(mount_path)])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -187,7 +187,7 @@ class TestBuildBwrapArgs:
     def test_blacklist_nonexistent_path_raises(self, tmp_path):
         nonexistent = tmp_path / "does_not_exist"
 
-        with pytest.raises(SystemExit, match="Blacklist path does not exist"):
+        with pytest.raises(SystemExit, match=r"(?s)paths that do not exist.*\[blacklist\]"):
             build_bwrap_args(
                 {"blacklist": [str(nonexistent)]},
                 tmp_path,
@@ -265,16 +265,23 @@ class TestBuildBwrapArgs:
         assert result[idx - 1] == "--bind"
         assert result[idx + 1] == resolved
 
-    def test_writable_nonexistent_creates_dir(self, tmp_path):
+    def test_writable_nonexistent_raises(self, tmp_path):
         nope = tmp_path / "nope"
-        assert not nope.exists()
-        result = build_bwrap_args(
-            {"writable": [str(nope)]},
-            tmp_path,
-        )
-        assert nope.is_dir()
-        assert "--bind" in result
-        assert str(nope) in result
+        with pytest.raises(SystemExit, match=r"(?s)paths that do not exist.*\[writable\]"):
+            build_bwrap_args({"writable": [str(nope)]}, tmp_path)
+        assert not nope.exists()  # must not be created on host
+
+    def test_missing_paths_aggregated(self, tmp_path):
+        miss_bl = tmp_path / "miss_bl"
+        miss_wr = tmp_path / "miss_wr"
+        with pytest.raises(SystemExit) as exc:
+            build_bwrap_args(
+                {"blacklist": [str(miss_bl)], "writable": [str(miss_wr)]},
+                tmp_path,
+            )
+        msg = str(exc.value)
+        assert f"[blacklist] {miss_bl}" in msg
+        assert f"[writable] {miss_wr}" in msg
 
     def test_writable_resolves_symlinks(self, tmp_path):
         target = tmp_path / "real"
@@ -588,7 +595,7 @@ class TestBlacklistErrors:
     def test_rejects_nonexistent_blacklist(self, tmp_path):
         nonexistent = tmp_path / "does_not_exist"
 
-        with pytest.raises(SystemExit, match="Blacklist path does not exist"):
+        with pytest.raises(SystemExit, match=r"(?s)paths that do not exist.*\[blacklist\]"):
             build_bwrap_args(
                 {"blacklist": [str(nonexistent)]},
                 tmp_path,


### PR DESCRIPTION
Final part of #2 
Better error reporting, and don't fall back to create dirs if they don't exist